### PR TITLE
Fix for exclusion of generated files when installing the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ installed automatically during the installation process:
 Older versions of this library featured a two-step build process. This has since
 been simplified. To install the package run pip:
 
-    pip install -e .
+    pip install <path/to/Philote-Python>
 
-If you want to install the package without editable mode, you will need to run the
-two-step process previously described. First, run:
+or
 
-    python utils/compile_proto.py
+    pip install -e <path/to/Philote-Python>
 
-followed by:
+for an editable install. Note, that <path/to/Philote-Python> is the path to the
+repository root directory (the one containing pyproject.toml). Often, people
+install packages when located in that directory, making the corresponding
+command:
 
     pip install .
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -21,22 +21,18 @@ installed automatically during the installation process:
 
 ## Compiling Definitions and Installation
 
-The Philote MDO Python library requires a two step installation process. First,
-make sure that `grpcio-tools` and `protoletariat` are installed. If not, they
-can be installed using pip. Note, that the first step of the installation
-process will not complete without these tools. Unlike the other dependencies,
-pip will not automatically install them during the package build. The first step
-is to compile the protobuf/gRPC files into python files. This is done by running
-(from the repository directory):
+Older versions of this library featured a two-step build process. This has since
+been simplified. To install the package run pip:
 
-    python setup.py compile_proto
-
-Once this step completes successfully, the package can be installed using pip:
-
-    pip install .
+    pip install <path/to/Philote-Python>
 
 or
 
-    pip install -e .
+    pip install -e <path/to/Philote-Python>
 
-for a development install.
+for an editable install. Note, that <path/to/Philote-Python> is the path to the
+repository root directory (the one containing pyproject.toml). Often, people
+install packages when located in that directory, making the corresponding
+command:
+
+    pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ homepage = "https://chrislupp.github.io/Philote-Python/"
 repository = "https://github.com/chrislupp/Philote-Python"
 documentation = "https://chrislupp.github.io/Philote-Python/"
 keywords = ["mdo", "optimization", "rpc"]
+include = ["philote_mdo/generated/*pb2.py", "philote_mdo/generated/*pb2.pyi", "philote_mdo/generated/*grpc.py"]
+
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -16,9 +18,11 @@ grpcio = "^1.62.0"
 numpy = "^1.26.4"
 scipy = "^1.12.0"
 
+
 [build-system]
 requires = ["poetry-core", "grpcio-tools", "protoletariat"]
 build-backend = "poetry.core.masonry.api"
+
 
 [tool.poetry.build]
 generate-setup-file = false


### PR DESCRIPTION
This PR addresses a case where installing the package will result in a broken installation as the generated files (from protoc) are not installed (Issue #20).