### PR TITLE
Fixes to discpline_server options

### DIFF
--- a/philote_mdo/general/discipline_server.py
+++ b/philote_mdo/general/discipline_server.py
@@ -102,7 +102,7 @@ class DisciplineServer(disc.DisciplineService):
 
             opts.type.append(type)
 
-            yield opts
+        return opts
 
     def SetOptions(self, request, context):
         """
@@ -110,6 +110,7 @@ class DisciplineServer(disc.DisciplineService):
         """
         options = request.options
         self._discipline.set_options(options)
+        return Empty()
 
     def Setup(self, request, context):
         """

--- a/philote_mdo/tests/test_discipline_server.py
+++ b/philote_mdo/tests/test_discipline_server.py
@@ -101,18 +101,14 @@ class TestDisciplineServer(unittest.TestCase):
                                            'option3': 'float'}
 
         # call the function
-        opts_generator = server.GetAvailableOptions(request_mock, context_mock)
-
-        # collect the yielded results
-        results = list(opts_generator)
+        results = server.GetAvailableOptions(request_mock, context_mock)
 
         # assert that the results are correct
         expected_options = ['option1', 'option2', 'option3']
         expected_types = [data.kBool, data.kInt, data.kDouble]
 
-        for result in results:
-            self.assertEqual(result.options, expected_options)
-            self.assertEqual(result.type, expected_types)
+        self.assertEqual(results.options, expected_options)
+        self.assertEqual(results.type, expected_types)
 
     def test_set_options(self):
         server = DisciplineServer()


### PR DESCRIPTION
- Added missing Empty return value to SetOptions. Fixes grpc error when clients try to call SetOptions.
- Reworked GetAvailableOptions to return a single OptionsList message to match protobuf spec. 
- Updated discipline server tests